### PR TITLE
linux: ensure tray icon display in linux sandboxed environments

### DIFF
--- a/lib/Utils/utils.dart
+++ b/lib/Utils/utils.dart
@@ -15,6 +15,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:cloudotp/Database/category_dao.dart';
@@ -603,11 +604,17 @@ class Utils {
       await trayManager.destroy();
       return;
     }
-    await trayManager.setIcon(
-      ResponsiveUtil.isWindows()
-          ? 'assets/logo-transparent.ico'
-          : 'assets/logo-transparent.png',
-    );
+
+    // Ensure tray icon display in linux sandboxed environments
+    if (Platform.environment.containsKey('FLATPAK_ID') ||
+        Platform.environment.containsKey('SNAP')) {
+      await trayManager.setIcon('com.cloudchewie.cloudotp');
+    } else if (ResponsiveUtil.isWindows()) {
+      await trayManager.setIcon('assets/logo-transparent.ico');
+    } else {
+      await trayManager.setIcon('assets/logo-transparent.png');
+    }
+
     var packageInfo = await PackageInfo.fromPlatform();
     bool lauchAtStartup = await LaunchAtStartup.instance.isEnabled();
     if (!ResponsiveUtil.isLinux()) {
@@ -675,11 +682,17 @@ class Utils {
       await trayManager.destroy();
       return;
     }
-    await trayManager.setIcon(
-      ResponsiveUtil.isWindows()
-          ? 'assets/logo-transparent.ico'
-          : 'assets/logo-transparent.png',
-    );
+
+    // Ensure tray icon display in linux sandboxed environments
+    if (Platform.environment.containsKey('FLATPAK_ID') ||
+        Platform.environment.containsKey('SNAP')) {
+      await trayManager.setIcon('com.cloudchewie.cloudotp');
+    } else if (ResponsiveUtil.isWindows()) {
+      await trayManager.setIcon('assets/logo-transparent.ico');
+    } else {
+      await trayManager.setIcon('assets/logo-transparent.png');
+    }
+
     var packageInfo = await PackageInfo.fromPlatform();
     bool lauchAtStartup = await LaunchAtStartup.instance.isEnabled();
     if (!ResponsiveUtil.isLinux()) {


### PR DESCRIPTION
当运行在flatpak或者snap环境时，需要将icon的路径设置为icon文件名，不然会显示一个空白的托盘图标

如果有需要的话，建议合并 pr 的时候选择 squash and merge，这样可以减少无用的commit信息